### PR TITLE
Fixed the loop upper limit

### DIFF
--- a/Go/go_redigo_performance.go
+++ b/Go/go_redigo_performance.go
@@ -5,7 +5,7 @@ import (
 	"github.com/garyburd/redigo/redis"
 )
 
-const N = 1600000
+const N = 1000000
 
 func main() {
 	c, err := redis.Dial("tcp", ":6379")


### PR DESCRIPTION
The loop should run 1 million times instead of 1.6 million times, as it does with all other benchmarks.
