### PR TITLE
Add rust benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ Java/jedis-2.7.2.tar.gz
 Java/*.class
 
 Node.js/node_modules
+
+Rust/target

--- a/Rust/Cargo.lock
+++ b/Rust/Cargo.lock
@@ -1,0 +1,87 @@
+[root]
+name = "rust-redis-client-performance"
+version = "0.1.0"
+dependencies = [
+ "redis 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "byteorder"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "matches"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redis"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha1 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sha1"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "url"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "uuid"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+

--- a/Rust/Cargo.toml
+++ b/Rust/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust-redis-client-performance"
+version = "0.1.0"
+authors = ["Matthew Rothenberg <mroth@mroth.info>"]
+
+[dependencies]
+redis = "0.5.2"

--- a/Rust/README.md
+++ b/Rust/README.md
@@ -1,0 +1,20 @@
+# Rust
+
+I used version Rust 1.7.0, installed via Homebrew.
+
+## Build
+
+```
+$ cargo build --release
+```
+
+## Run
+
+```
+$ time ./target/release/rust-redis-client-performance
+```
+
+## My Result
+
+TODO: Update with results from original maintainers hardware (otherwise not
+comparable).

--- a/Rust/src/main.rs
+++ b/Rust/src/main.rs
@@ -1,0 +1,13 @@
+extern crate redis;
+use redis::PipelineCommands;
+
+fn main() {
+    let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+    let con = client.get_connection().unwrap();
+
+    let mut pipeline = redis::pipe();
+    for _ in 1..1_000_000 {
+        pipeline.set("foo", "bar").ignore();
+    }
+    pipeline.execute(&con);
+}


### PR DESCRIPTION
First, thanks so much for doing these.  This is very helpful to me as I run an application where the vast majority of the CPU one service spends is talking to Redis (the other half is talking to the Twitter Streaming API, hence my similar benchmark repo at https://github.com/mroth/twitter-streaming-showdown/)

_Note this has a TODO in the Rust README in lieu of actual benchmark numbers, since otherwise it wouldn’t be comparable as I am on different hardware than you._

For the quick sake of comparison on my hardware though (4GHz Core i7, 32GB RAM, Redis 3.0.7 running on localhost):

```
ruby_redisrb_hiredis_performance.rb  4.99s user 0.24s system 89% cpu 5.856 total
go_redigo_performance                0.38s user 0.04s system 43% cpu 0.973 total
crystal_redis_performance            0.37s user 0.08s system 44% cpu 0.993 total
rust-redis-client-performance        1.21s user 0.11s system 61% cpu 2.146 total
```

I found these numbers are a bit surprising, and suggest the Rust redis crate may have significant optimization work remaining to be done (either that or I did something grossly incorrect).
