### PR TITLE
bump library version dep for crystal

### DIFF
--- a/Crystal/shard.lock
+++ b/Crystal/shard.lock
@@ -2,5 +2,5 @@ version: 1.0
 shards:
   redis:
     git: https://github.com/stefanwille/crystal-redis.git
-    version: 1.3.0
+    version: 1.5.1
 

--- a/Crystal/shard.yml
+++ b/Crystal/shard.yml
@@ -4,6 +4,6 @@ version: 0.1.0
 dependencies:
   redis:
     git: https://github.com/stefanwille/crystal-redis.git
-    version: 1.3.0
+    version: 1.5.1
 
 license: BSD


### PR DESCRIPTION
when attempting to run these on my own with the most recent version of
crystal, I found it would not compile. thus, I simply bumped to the most
recent version of the library so that things would compile fine in order
to replicate the tests.
