### PR TITLE
Add Ubuntu instructions and c99 compiler flag

### DIFF
--- a/C/README.md
+++ b/C/README.md
@@ -10,11 +10,16 @@ On MacOs X, install via
 $ brew install hiredis
 ```
 
+On Ubuntu-like Linux distros, install via
+
+```
+$ sudo apt-get install libhiredis0.10 libhiredis-dev
+```
 
 ## Build
 
 ```
-$ gcc -Wall -O2 c_hiredis_performance.c -lhiredis -o c_hiredis_performance
+$ gcc -Wall -std=c99 -O2 c_hiredis_performance.c -lhiredis -o c_hiredis_performance
 ```
 
 


### PR DESCRIPTION
Added C99 compiler flag to compile on my gcc version 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04.3)
