### PR TITLE
Use redisAppendCommandArgv instead of redisAppendCommand

### DIFF
--- a/C/c_hiredis_performance.c
+++ b/C/c_hiredis_performance.c
@@ -3,6 +3,9 @@
 
 const int N = 1000000;
 
+const char *ARGV[] = { "SET", "foo", "bar" };
+const size_t ARGC[] = { 3, 3, 3 };
+
 int main () {
   printf("Connecting...\n");
   redisContext *redis = redisConnect("localhost", 6379);
@@ -18,7 +21,7 @@ int main () {
     // void *redisCommand(redisContext *c, const char *format, ...);
 
     for(int i = 0; i < N; i++) {
-      redisAppendCommand(redis,"SET foo bar");
+      redisAppendCommandArgv(redis, 3, ARGV, ARGC);
     }
 
     for(int i = 0; i < N; i++) {


### PR DESCRIPTION
Since we're sending the same command over and over we don't need to
recalculate the arguments each time.

I think this provides a better representation of hiredis performance.  I always use the *argv methods for any massively pipelined operations anyway.